### PR TITLE
Updated to use babel-preset-env instead of babel-preset-es2015

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,13 @@
 {
     "presets": [
-        "env",
+        ["env", {
+          "targets": {
+            "browsers": [ ">0.25%"]
+          }
+        }],
         "react"
     ],
-    "plugins": [        
+    "plugins": [
         "transform-object-rest-spread",
         "transform-react-jsx"
     ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = {
         test: /\.jsx?$/,
         loader: 'babel-loader',
         query: {
-            presets: ['es2015']
+            presets: ['env']
         }
       }
     ]


### PR DESCRIPTION
I noticed when trying this skeleton project out that on `npm start` the build will fail, due to missing the `babel-preset-es2015` plugin. As this plugin is deprecated, I set up `.babelrc` and `webpack.config.js` to use the preferred `babel-preset-env`.